### PR TITLE
Add missing require form

### DIFF
--- a/world-time-mode.el
+++ b/world-time-mode.el
@@ -26,6 +26,7 @@
 ;;; Code:
 
 (require 'cl)
+(require 'time)
 
 (defun world-time/table-entrys ()
   "For listing the entries of the world-time day."


### PR DESCRIPTION
This commit fix a following error:

```
world-time-list: Symbol's value as variable is void: display-time-world-list
```
