### PR TITLE
Quick patches

### DIFF
--- a/world-time-mode.el
+++ b/world-time-mode.el
@@ -1,10 +1,15 @@
-;;; world-time-mode.el --- show whole days of world-time diffs
+;;; world-time-mode.el --- Show whole days of world-time diffs -*- lexical-binding: t -*-
 
 ;; Copyright (C) 2013  Nic Ferrier
 
 ;; Author: Nic Ferrier <nferrier@ferrier.me.uk>
+;; URL: https://github.com/nicferrier/emacs-world-time-mode
+;; Package-Requires: ((emacs "24.1") (cl-lib "0.5"))
 ;; Keywords: tools, calendar
+;; SPDX-License-Identifier: GPL-3.0-or-later
 ;; Version: 0.0.6
+
+;; This file is not part of GNU Emacs.
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -25,7 +30,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 (require 'time)
 
 (defun world-time/zone-list (time)
@@ -56,7 +61,7 @@ Based on the next hour after the current time."
           (mapcar
            (lambda (i)
              (list nil
-                   (world-time/zone-list 
+                   (world-time/zone-list
                     (time-add ref-time (seconds-to-time (* 3600.00 i))))))
            (number-sequence 0 23))))
     (append (list (list nil (world-time/zone-list currently))) ref-list)))

--- a/world-time-mode.el
+++ b/world-time-mode.el
@@ -28,7 +28,7 @@
 (require 'cl)
 (require 'time)
 
-(defun world-time/zone-list (this-time)
+(defun world-time/zone-list (time)
   "Return the vector of zoned times for TIME."
   (apply 'vector
          (mapcar
@@ -37,7 +37,7 @@
               (unwind-protect
                    (progn
                      (setenv "TZ" (car zone))
-                     (list (format-time-string "%R %Z" this-time)))
+                     (list (format-time-string "%R %Z" time)))
                 (setenv "TZ" original))))
           display-time-world-list)))
 

--- a/world-time-mode.el
+++ b/world-time-mode.el
@@ -48,7 +48,7 @@
         (and (boundp 'zoneinfo-style-world-list)
              (symbol-value 'zoneinfo-style-world-list))))))
 
-(defun world-time/zone-list (time)
+(defun world-time--zone-list (time)
   "Return the vector of zoned times for TIME."
   (apply 'vector
          (mapcar
@@ -62,7 +62,7 @@
           (world-time--world-list))))
 
 
-(defun world-time/table-entrys ()
+(defun world-time--table-entries ()
   "Make the entry table for the list.
 
 Based on the next hour after the current time."
@@ -76,15 +76,15 @@ Based on the next hour after the current time."
           (mapcar
            (lambda (i)
              (list nil
-                   (world-time/zone-list
+                   (world-time--zone-list
                     (time-add ref-time (seconds-to-time (* 3600.00 i))))))
            (number-sequence 0 23))))
-    (append (list (list nil (world-time/zone-list currently))) ref-list)))
+    (append (list (list nil (world-time--zone-list currently))) ref-list)))
 
 (define-derived-mode
     world-time-table-mode tabulated-list-mode "World Time"
     "Major mode for seeing your world time list as a day."
-    (setq tabulated-list-entries 'world-time/table-entrys)
+    (setq tabulated-list-entries 'world-time--table-entries)
     ;; This is wrong! it needs to be derived from (world-time--world-list)
     (setq tabulated-list-format
           (cl-loop for time in (world-time--world-list)


### PR DESCRIPTION
In recent Emacs, the variable `display-time-world-list` can have `t` as a valid value which breaks `world-time-mode`. Here is a quick patch to fix that and also some package-lint/checkdoc warnings.